### PR TITLE
Add some unittests

### DIFF
--- a/snugh/lecture/tests.py
+++ b/snugh/lecture/tests.py
@@ -1,4 +1,390 @@
 from django.test import TestCase
+from user.models import User, Major, UserMajor, UserProfile
+from rest_framework import status
+from pathlib import Path
+from django.db.models import Q
+from user.utils import UserFactory, UserMajorFactory
+from .utils import SemesterFactory, SemesterLectureFactory
+from .models import Lecture, Plan, PlanMajor, Semester, SemesterLecture
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-# TODO: Write a new test case
+class LectureListDeleteTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cls.user = UserFactory.create()
+        cls.user_token = "Token " + str(cls.user.auth_token)
+        
+        cls.plan = Plan.objects.create(user=cls.user, plan_name="test")
+
+        cls.semesters = SemesterFactory.create(
+            semesters=[
+                {
+                    "plan":cls.plan,
+                    "year":2016,
+                    "semester_type":"first",
+                    "major_requirement_credit":6,
+                    "major_elective_credit":9
+                },
+                {
+                    "plan":cls.plan,
+                    "year":2021,
+                    "semester_type":"first"
+                }
+            ]
+        )
+        
+        # bulk_create()가 mysql에서는 id가 none인 저장 안된 object들을 retrieve하기 때문에
+        # .get으로 별도로 retrieve 해줬습니다. 
+        cls.semester_2016 = Semester.objects.get(year=2016, semester_type="first")
+        cls.semester_2021 = Semester.objects.get(year=2021, semester_type="first")
+        cls.major = Major.objects.get(major_name="경영학과", major_type="major")
+        cls.planmajor = PlanMajor.objects.create(major=cls.major, plan=cls.plan)
+        cls.my_lectures = [
+            "경영과학", 
+            "디자인 사고와 혁신", 
+            "고급회계",
+            "공급사슬관리",
+            "국제경영"
+        ]
+        cls.lectures = Lecture.objects.filter(lecture_name__in=cls.my_lectures)
+
+        cls.semesterlectures = SemesterLectureFactory.create(
+            semester=cls.semester_2016,
+            lectures=cls.lectures,
+            recognized_majors=[cls.major]*5
+        )
+        
+    # GET /lecture/
+    def test_lecture_list(self):
+
+        # 과거 기준 전필 조회
+        body = {
+            "search_type": "major_requirement", 
+            "search_year": 2016, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertEqual(data[i]["open_major"], self.major.major_name)
+            self.assertEqual(data[i]["lecture_type"], "major_requirement")
+            self.assertEqual((data[i]["recent_open_year"]>=2016), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+            if i!=cnt-1:
+                # 정렬 check
+                self.assertEqual((data[i]["lecture_name"]<=data[i+1]["lecture_name"]), True)
+
+        # 미래 기준 전필 조회
+        body = {
+            "search_type": "major_requirement", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertEqual(data[i]["open_major"], self.major.major_name)
+            self.assertEqual(data[i]["lecture_type"], "major_requirement")
+            self.assertEqual((data[i]["recent_open_year"]>=2019), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+            if i!=cnt-1:
+                # 정렬 check
+                self.assertEqual((data[i]["lecture_name"]<=data[i+1]["lecture_name"]), True)
+
+        # 과거 기준 전선 조회
+        body = {
+            "search_type": "major_elective", 
+            "search_year": 2016, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertEqual(data[i]["open_major"], self.major.major_name)
+            self.assertEqual(data[i]["lecture_type"], "major_elective")
+            self.assertEqual((data[i]["recent_open_year"]>=2016), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+            if i!=cnt-1:
+                # 정렬 check
+                self.assertEqual((data[i]["lecture_name"]<=data[i+1]["lecture_name"]), True)
+                
+        # 미래 기준 전선 조회
+        body = {
+            "search_type": "major_elective", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertEqual(data[i]["open_major"], self.major.major_name)
+            self.assertEqual(data[i]["lecture_type"], "major_elective")
+            self.assertEqual((data[i]["recent_open_year"]>=2019), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+            if i!=cnt-1:
+                # 정렬 check
+                self.assertEqual((data[i]["lecture_name"]<=data[i+1]["lecture_name"]), True)
+
+
+        # 과거 기준 키워드 검색
+        body = {
+            "search_type": "keyword", 
+            "search_year": 2016, 
+            "search_keyword":"경영", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertIn("경영", data[i]["lecture_name"])
+            self.assertEqual((data[i]["recent_open_year"]>=2016), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+        # 미래 기준 키워드 검색
+        body = {
+            "search_type": "keyword", 
+            "search_year": 2021, 
+            "search_keyword":"경영", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        cnt = len(data)
+        for i in range(cnt):
+            self.assertIn("경영", data[i]["lecture_name"])
+            self.assertEqual((data[i]["recent_open_year"]>=2016), True)
+
+            # 이미 추가한 강의 있는지 check
+            self.assertNotIn(data[i]["lecture_name"], self.my_lectures)
+
+    def test_lecture_list_error(self):
+
+        wrong_body = {
+            "search_type": "", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "search_type missing")
+
+        wrong_body = {
+            "search_type": "major_elective", 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "search_year missing")
+
+        wrong_body = {
+            "search_type": "keyword", 
+            "search_keyword":"", 
+            "major_name":self.major.major_name,
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "search_year missing")
+
+        wrong_body = {
+            "search_type": "major_requirement", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":"",
+            "plan_id":self.plan.id
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "major_name missing")
+
+        wrong_body = {
+            "search_type": "major_requirement", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "plan_id missing")
+
+        wrong_body = {
+            "search_type": "keyword", 
+            "search_year": 2021, 
+            "search_keyword":"", 
+            "major_name":self.major.major_name
+        }
+        response = self.client.get(
+            "/lecture/",
+            data=wrong_body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data['error'], "plan_id missing")
+        
+        
+    # DELETE /lecture/
+    def test_lecture_delete(self):
+        
+        self.assertEqual(
+            self.semester_2016.semesterlecture.filter(
+                lecture__lecture_name="공급사슬관리").exists(), True)
+        lecture_id = self.semester_2016.semesterlecture.get(lecture__lecture_name="공급사슬관리").id
+        
+        response = self.client.delete(
+            f"/lecture/{lecture_id}/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            self.semester_2016.semesterlecture.filter(
+                lecture__lecture_name="공급사슬관리").exists(), False)
+
+        response = self.client.delete(
+            f"/lecture/{lecture_id}/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.semester_2016.refresh_from_db()
+        self.assertEqual(self.semester_2016.major_elective_credit, 6)
+
+
+    """
+    # PUT lecture/<lecture_id>/position
+    def test_lecture_position(self):
+
+        first_lectures = SemesterLecture.objects.select_related("lecture").filter(semester=self.semester_1)
+        target_lecture = first_lectures.get(lecture__lecture_name="경영과학").lecture
+        semester_from_id = self.semester_1.id
+        semester_to_id = self.semester_2.id
+
+        semester_to_list = [target_lecture.id]
+        semester_from_list = list(first_lectures).remove(target_lecture)
+        body = {
+            "semester_to_id":semester_to_id,
+            "semester_from_id":semester_from_id,
+            "semester_to":semester_to_list,
+            "semester_from":semester_from_list
+        }
+
+        response = self.client.put(
+            f"/lecture/{target_lecture.id}/position/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    """

--- a/snugh/lecture/tests.py
+++ b/snugh/lecture/tests.py
@@ -479,7 +479,10 @@ class SemesterTestCase(TestCase):
         # bulk_create()가 mysql에서는 id가 none인 저장 안된 object들을 retrieve하기 때문에
         # .get으로 별도로 retrieve 해줬습니다. 
         cls.semester_2016 = Semester.objects.get(year=2016, semester_type="first")
+        
+        # for testing deletion
         cls.semester_2021 = Semester.objects.get(year=2021, semester_type="first")
+        
         cls.major = Major.objects.get(major_name="경영학과", major_type="major")
         cls.planmajor = PlanMajor.objects.create(major=cls.major, plan=cls.plan)
         cls.lectures_list_2016 = [
@@ -493,6 +496,12 @@ class SemesterTestCase(TestCase):
 
         cls.semesterlectures_2016 = SemesterLectureFactory.create(
             semester=cls.semester_2016,
+            lectures=cls.lectures_2016,
+            recognized_majors=[cls.major]*5
+        )
+
+        cls.semesterlectures_2021 = SemesterLectureFactory.create(
+            semester=cls.semester_2021,
             lectures=cls.lectures_2016,
             recognized_majors=[cls.major]*5
         )
@@ -531,4 +540,15 @@ class SemesterTestCase(TestCase):
     
     # DELETE semester/<semester_id>/
     def test_semester_delete(self):
-        pass
+
+        # semester delete
+        response = self.client.delete(
+            f"/semester/{self.semester_2021.id}/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        semester_2021 = Semester.objects.filter(plan=self.plan, year=2021, semester_type='first').exists()
+        self.assertEqual(semester_2021, False)
+

--- a/snugh/lecture/utils.py
+++ b/snugh/lecture/utils.py
@@ -1,0 +1,72 @@
+from factory.django import DjangoModelFactory
+from .models import Semester, Lecture, Semester, SemesterLecture, Major
+
+class SemesterFactory(DjangoModelFactory):
+    class Meta:
+        model = Semester
+
+    @classmethod
+    def create(cls, **kwargs):
+
+        semesters = kwargs.get("semesters")
+        semesters_created=[]
+
+        for semester in semesters:
+            plan = semester.get("plan")
+            year = semester.get("year")
+            semester_type = semester.get("semester_type")
+            major_requirement_credit = semester.get("major_requirement_credit", 0)
+            major_elective_credit = semester.get("major_elective_credit", 0)
+            general_credit = semester.get("general_credit", 0)
+            general_elective_credit = semester.get("general_elective_credit", 0)
+            semesters_created.append(
+                Semester(
+                    plan=plan, 
+                    year=year, 
+                    semester_type=semester_type,
+                    major_requirement_credit=major_requirement_credit,
+                    major_elective_credit=major_elective_credit,
+                    general_credit=general_credit,
+                    general_elective_credit=general_elective_credit
+                )
+            )
+
+        if len(semesters_created) > 0:
+            return Semester.objects.bulk_create(semesters_created)
+        
+        return None
+
+class SemesterLectureFactory(DjangoModelFactory):
+    class Meta:
+        model = SemesterLecture
+
+    @classmethod
+    def create(cls, **kwargs): 
+
+
+        lectures = kwargs.get("lectures")
+        lectures_created = []
+        semester = kwargs.get("semester")
+        recoginized_majors = kwargs.get("recognized_majors")
+
+        if not (semester or lectures):
+            return None
+
+        for i, lecture in enumerate(lectures):
+
+            lectures_created.append(
+                SemesterLecture(
+                    semester=semester,
+                    lecture=lecture,
+                    lecture_type=lecture.lecture_type,
+                    recognized_major1=recoginized_majors[i],
+                    lecture_type1=lecture.lecture_type,
+                    credit=lecture.credit,
+                    recent_sequence=i
+                )
+            )
+        
+        if len(lectures_created) > 0 :
+            return SemesterLecture.objects.bulk_create(lectures_created)
+
+        return None

--- a/snugh/lecture/views.py
+++ b/snugh/lecture/views.py
@@ -885,33 +885,32 @@ class LectureViewSet(viewsets.GenericViewSet):
         if not search_type:
             return Response({ "error": "search_type missing" }, status=status.HTTP_400_BAD_REQUEST)
 
-        # search_year = request.query_params.get("search_year")
-        # if not search_year:
-        #     return Response({"error": "search_year missing"}, status=status.HTTP_400_BAD_REQUEST)
-        #
-        # plan_id = request.query_params.get("plan_id")
-        # if not plan_id:
-        #     return Response({"error": "plan_id missing"}, status=status.HTTP_400_BAD_REQUEST)
+        search_year = request.query_params.get("search_year")
+        if not search_year:
+            return Response({"error": "search_year missing"}, status=status.HTTP_400_BAD_REQUEST)
+        
+        plan_id = request.query_params.get("plan_id")
+        if not plan_id:
+            return Response({"error": "plan_id missing"}, status=status.HTTP_400_BAD_REQUEST)
 
-#        existing_lectures = Lecture.objects.filter(semesterlecture__semester__plan = Plan.objects.get(id=plan_id)).values_list('id', flat=True)
+        existing_lectures = Lecture.objects.filter(semesterlecture__semester__plan = Plan.objects.get(id=plan_id)).values_list('id', flat=True)
 
         # Case 1: major requirement or major elective
         if search_type == 'major_requirement' or search_type == 'major_elective':
             major_name = request.query_params.get("major_name")
             if major_name:
-                # 시연에서만
-                search_year = 2019
 
                 if int(search_year) < Lecture.UPDATED_YEAR:
                     year_standard = search_year
                 else:
                     year_standard = Lecture.UPDATED_YEAR-2
 
-                lectures = Lecture.objects.filter(open_major=major_name, lecture_type=search_type,
-                                                  recent_open_year__gte = year_standard) \
-                    .order_by('lecture_name', 'recent_open_year')
-                # lectures = Lecture.objects.filter(open_major=major_name, lecture_type=search_type, recent_open_year__gte=user.userprofile.entrance_year)\
-                #     .exclude(id__in=existing_lectures).order_by('lecture_name', 'recent_open_year')
+                # lectures = Lecture.objects.filter(open_major=major_name, lecture_type=search_type,
+                #                                   recent_open_year__gte = year_standard) \
+                #     .order_by('lecture_name', 'recent_open_year')
+                lectures = Lecture.objects.filter(open_major=major_name, lecture_type=search_type, recent_open_year__gte=year_standard)\
+                    .exclude(id__in=existing_lectures).order_by('lecture_name', 'recent_open_year')
+                
                 if DepartmentEquivalent.objects.filter(major_name=major_name).count() != 0:
                     department_name = DepartmentEquivalent.objects.get(major_name=major_name).department_name
                     # TODO: |= inefficient
@@ -960,30 +959,30 @@ class LectureViewSet(viewsets.GenericViewSet):
             if search_keyword:
                 # past lectures
                 if int(search_year) < Lecture.UPDATED_YEAR:
-                    # .exclude(id__in=existing_lectures) \
                     lectures = Lecture.objects.search(search_keyword).filter(recent_open_year__gte = search_year)\
-                        .annotate(first_letter=Case(When(lecture_name__startswith=search_keyword[0], then=models.Value(0)),
-                                                default=models.Value(1),
-                                                output_field=models.IntegerField(),))\
-                        .annotate(icontains_priority=Case(When(lecture_name__icontains=search_keyword, then=models.Value(0)),
-                                                default=models.Value(1),
-                                                output_field=models.IntegerField(),))\
-                        .annotate(priority = F('first_letter')+F('icontains_priority'))\
-                        .annotate(match_rate=Length('lecture_name'))\
-                        .order_by('priority', 'match_rate', 'recent_open_year', 'lecture_name')
+                        .exclude(id__in=existing_lectures)\
+                            .annotate(first_letter=Case(When(lecture_name__startswith=search_keyword[0], then=models.Value(0)),
+                                                    default=models.Value(1),
+                                                    output_field=models.IntegerField(),))\
+                            .annotate(icontains_priority=Case(When(lecture_name__icontains=search_keyword, then=models.Value(0)),
+                                                    default=models.Value(1),
+                                                    output_field=models.IntegerField(),))\
+                            .annotate(priority = F('first_letter')+F('icontains_priority'))\
+                            .annotate(match_rate=Length('lecture_name'))\
+                            .order_by('priority', 'match_rate', 'recent_open_year', 'lecture_name')
                 # future lectures
                 else:
-                    # .exclude(id__in=existing_lectures) \
                     lectures = Lecture.objects.search(search_keyword).filter(recent_open_year__gte=Lecture.UPDATED_YEAR-2) \
-                        .annotate(first_letter=Case(When(lecture_name__startswith=search_keyword[0], then=models.Value(0)),
-                                          default=models.Value(1),
-                                          output_field=models.IntegerField(), )) \
-                        .annotate(icontains_priority=Case(When(lecture_name__icontains=search_keyword, then=models.Value(0)),
-                                                default=models.Value(1),
-                                                output_field=models.IntegerField(), )) \
-                        .annotate(priority=F('first_letter') + F('icontains_priority')) \
-                        .annotate(match_rate=Length('lecture_name'))\
-                        .order_by('priority', 'match_rate', '-recent_open_year', 'lecture_name')
+                        .exclude(id__in=existing_lectures)\
+                            .annotate(first_letter=Case(When(lecture_name__startswith=search_keyword[0], then=models.Value(0)),
+                                            default=models.Value(1),
+                                            output_field=models.IntegerField(), )) \
+                            .annotate(icontains_priority=Case(When(lecture_name__icontains=search_keyword, then=models.Value(0)),
+                                                    default=models.Value(1),
+                                                    output_field=models.IntegerField(), )) \
+                            .annotate(priority=F('first_letter') + F('icontains_priority')) \
+                            .annotate(match_rate=Length('lecture_name'))\
+                            .order_by('priority', 'match_rate', '-recent_open_year', 'lecture_name')
                 lectures = Paginator(lectures, 20).get_page(page)
                 serializer = LectureSerializer(lectures, many=True)
                 return Response(serializer.data, status=status.HTTP_200_OK)

--- a/snugh/requirements.txt
+++ b/snugh/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.2.10
-Django>=3.1.13
+Django<=4.0
 django-debug-toolbar==2.2.1
 django-dotenv==1.4.2
 djangorestframework==3.11.2
@@ -9,3 +9,6 @@ pytz==2020.1
 sqlparse==0.3.1
 Pillow==8.3.2
 uwsgi
+django-redis
+factory-boy==3.2.1
+Faker==9.8.3

--- a/snugh/snugh/settings/settings_test.py
+++ b/snugh/snugh/settings/settings_test.py
@@ -1,0 +1,3 @@
+from .local import *
+
+TEST_RUNNER = 'snugh.settings.test_runner.TestRunner'

--- a/snugh/snugh/settings/test_runner.py
+++ b/snugh/snugh/settings/test_runner.py
@@ -1,0 +1,9 @@
+from django.test.runner import DiscoverRunner
+
+class TestRunner(DiscoverRunner):
+
+    def setup_databases(self, **kwargs):
+        pass
+
+    def teardown_databases(self, old_config, **kwargs):
+        pass

--- a/snugh/user/tests.py
+++ b/snugh/user/tests.py
@@ -1,4 +1,303 @@
 from django.test import TestCase
+from .models import User, Major, UserMajor, UserProfile
+from rest_framework import status
+from pathlib import Path
+from django.db.models import Q
+from .utils import UserFactory, UserMajorFactory
+from django.db.models import Count
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-# TODO: Write a new test case
+class MajorTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory.create()
+        cls.user_token = "Token " + str(cls.user.auth_token)
+    
+    # GET major/
+    def test_major_list(self):
+
+        # 중복여부, 정렬여부, None여부 확인 가능
+        # None 값 제거 (-1)
+        all_majors_cnt = Major.objects.values("major_name").distinct().count()-1
+
+        # major_type 없고 search_keyword 없을 때 -> 모든 major 리턴
+        body = {}
+        response = self.client.get(
+            "/major/",
+            data=body,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(len(data["majors"]), all_majors_cnt)
+
+        for i in range(5):
+            self.assertEqual((data["majors"][i]<=data["majors"][i+1]), True)
+            self.assertEqual((data["majors"][-i-2]<=data["majors"][-i-1]), True)
+        
+
+        # major_type 있고 search_keyword 있을 때 -> 해당 major_type중 search_keyword를 포함한 major들을 리턴
+        body = {
+            "major_type": "interdisciplinary_major",
+            "search_keyword": "경영",
+        }
+
+        response = self.client.get(
+            "/major/",
+            data=body,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        results = [
+            "글로벌환경경영학",
+            "기술경영",
+            "벤처경영학"
+        ]
+
+        self.assertEqual(len(data["majors"]), len(results))
+
+        for idx, major_name in enumerate(results):
+            self.assertEqual(data["majors"][idx], major_name)
+
+        # major_type 없고 search_keyword 있을 때 -> search_keyword를 포함한 major만 리턴
+        body = {"search_keyword": "경영"}
+        response = self.client.get(
+            "/major/",
+            data=body,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        results = [
+            "경영학과",
+            "글로벌환경경영학",
+            "기술경영",
+            "벤처경영학",
+            "협동과정 기술경영·경제·정책전공",
+            "협동과정 미술경영"
+        ]
+
+        self.assertEqual(len(data["majors"]), len(results))
+
+        for idx, major_name in enumerate(results):
+            self.assertEqual(data["majors"][idx], major_name)
+
+        # major_type 있고 search_keyword 없을 때 -> 해당 major_type의 모든 major 리턴
+        body = {
+            "major_type": "interdisciplinary_major",
+        }
+        response = self.client.get(
+            "/major/",
+            data=body,
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        results = [
+            "계산과학",
+            "글로벌환경경영학",
+            "기술경영",
+            "동아시아비교인문학",
+            "벤처경영학",
+            "영상매체예술",
+            "인공지능",
+            "인공지능반도체공학",
+            "정보문화학"
+        ]
+
+        self.assertEqual(len(data["majors"]), len(results))
+
+        for idx, major_name in enumerate(results):
+            self.assertEqual(data["majors"][idx], major_name)
+
+    # POST user/major/
+    def test_major_create(self):
+
+        body = {"major_type": "major", "major_name": "경영학과"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["majors"][0]["major_name"], "경영학과")
+        self.assertEqual(data["majors"][0]["major_type"], "major")
+
+        body = {"major_type": "single_major", "major_name": "컴퓨터공학부"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["majors"][0]["major_name"], "경영학과")
+        self.assertEqual(data["majors"][0]["major_type"], "major")
+        self.assertEqual(data["majors"][1]["major_name"], "컴퓨터공학부")
+        self.assertEqual(data["majors"][1]["major_type"], "major")
+
+        body = {"major_type": "interdisciplinary_major", "major_name": "인공지능"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+
+        self.assertEqual(data["majors"][0]["major_name"], "경영학과")
+        self.assertEqual(data["majors"][0]["major_type"], "major")
+        self.assertEqual(data["majors"][1]["major_name"], "컴퓨터공학부")
+        self.assertEqual(data["majors"][1]["major_type"], "major")
+        self.assertEqual(data["majors"][2]["major_name"], "인공지능")
+        self.assertEqual(data["majors"][2]["major_type"], "interdisciplinary_major")
+
+        usermajors = self.user.usermajor.select_related("major").all()
+        self.assertEqual(
+            usermajors.filter(
+                major__major_name="경영학과", major__major_type="major"
+            ).exists(),
+            True,
+        )
+        self.assertEqual(
+            usermajors.filter(
+                major__major_name="컴퓨터공학부", major__major_type="major"
+            ).exists(),
+            True,
+        )
+        self.assertEqual(
+            usermajors.filter(
+                major__major_name="인공지능", major__major_type="interdisciplinary_major"
+            ).exists(),
+            True,
+        )
+
+    def test_major_create_error(self):
+
+        # Major does not exist
+        body = {"major_type": "major", "major_name": "샤프심학과"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["error"], "major not_exist")
+
+        # Major already exists
+        body = {"major_type": "major", "major_name": "경영학과"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        body = {"major_type": "double_major", "major_name": "경영학과"}
+        response = self.client.post(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["error"], "major already_exist")
+
+    # DELETE /user/major
+    def test_major_delete(self):
+
+        UserMajorFactory.create(
+            user=self.user,
+            majors=Major.objects.filter(
+                (Q(major_name="경영학과") | Q(major_name="컴퓨터공학부")) & Q(major_type="major")
+            ),
+        )
+
+        body = {"major_type": "major", "major_name": "컴퓨터공학부"}
+        response = self.client.delete(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(len(data["majors"]), 1)
+        self.assertEqual(data["majors"][0]["major_name"], "경영학과")
+        self.assertEqual(data["majors"][0]["major_type"], "single_major")
+
+        usermajors = self.user.usermajor.select_related("major").all()
+        self.assertEqual(
+            usermajors.filter(
+                major__major_name="경영학과", major__major_type="major"
+            ).exists(),
+            False,
+        )
+        self.assertEqual(
+            usermajors.filter(
+                major__major_name="경영학과", major__major_type="single_major"
+            ).exists(),
+            True,
+        )
+
+    def test_major_delete_error(self):
+
+        UserMajorFactory.create(
+            user=self.user,
+            majors=Major.objects.filter(Q(major_name="경영학과") & Q(major_type="major")),
+        )
+
+        # Major does not exist
+        body = {"major_type": "major", "major_name": "샤프심학과"}
+        response = self.client.delete(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["error"], "major not_exist")
+
+        # UserMajor does not exist
+        body = {"major_type": "major", "major_name": "컴퓨터공학부"}
+        response = self.client.delete(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["error"], "usermajor not_exist")
+
+        # UserMajor cannot be zero or minus
+        body = {"major_type": "major", "major_name": "경영학과"}
+        response = self.client.delete(
+            "/user/major/",
+            data=body,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=self.user_token,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["error"], "The number of majors cannot be zero or minus.")

--- a/snugh/user/tests.py
+++ b/snugh/user/tests.py
@@ -9,7 +9,15 @@ from django.db.models import Count
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
-class MajorTestCase(TestCase):
+class UserMajorTestCase(TestCase):
+    """
+    # Test
+
+    [GET] major/
+    [POST] user/major/
+    [DELETE] user/major/
+    """
+
 
     @classmethod
     def setUpTestData(cls):

--- a/snugh/user/utils.py
+++ b/snugh/user/utils.py
@@ -1,0 +1,53 @@
+from factory.django import DjangoModelFactory
+from faker import Faker
+from .models import User, UserMajor, UserProfile
+from rest_framework.authtoken.models import Token
+
+class UserFactory(DjangoModelFactory):
+    class Meta:
+        model = User
+
+    #email = "test@test.com"
+    idx = 0
+
+    @classmethod
+    def create(cls, **kwargs):
+
+        fake = Faker("ko_KR")
+        email = kwargs.get("email", f"test{cls.idx}@snu.ac.kr")
+
+        user = User.objects.create(
+            username=email,
+            email=email,
+            password=kwargs.get("password", fake.password()),
+            first_name=kwargs.get("full_name", fake.name())
+            )
+
+        UserProfile.objects.create(
+            user=user, 
+            entrance_year=fake.random_choices(
+                elements=(2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021), length=1)[0], 
+            status="active"
+            )
+        
+        token, created = Token.objects.get_or_create(user=user)
+        
+        cls.idx += 1
+        return user
+
+class UserMajorFactory(DjangoModelFactory):
+    class Meta:
+        model = UserMajor
+
+    @classmethod
+    def create(cls, **kwargs):
+
+        user = kwargs.get("user", None)
+        majors = kwargs.get("majors", None)
+        
+        if user and majors:
+
+            usermajors = [UserMajor(user=user, major=major) for major in majors]
+            return UserMajor.objects.bulk_create(usermajors)
+        
+        return None


### PR DESCRIPTION
아래 API에 대하여 unittest를 추가해주었습니다. TestCase를 어떤 단위로 분류할까 고민하다가 아래와 같이 정의해보았습니다. 아래와 같이 ViewSet 단위로 TestCase를 묶어주고 아예 새로운 Setupdata가 필요하거나 결이 다른 기능의 API인 경우 새로 TestCase class를 작성해주시면 되지 않을까 생각합니다. test 수준은 구체적이면 좋으나, 코드를 유지 보수할 때 해당 api의 로직을 해치지 않게 체크할 수 있는 정도면 될 것 같습니다. 

테스트 방식은 저번에 의논했던 대로 각 개인의 로컬에 다운되어 있는 서버 데이터 사본을 이용하는 방향으로 하면 될 것 같습니다. 제 코드에 있는 settings.test.py와 test_runner.py를 해당 디렉토리에 생성하신 후에
./manage.py test <test할 app> --settings='snugh.settings.settings_test' 명령어로 테스트 돌려주시면 될 것 같습니다.

TestCase를 묶는 방향에 대해 다른 의견이 있으면 말씀 부탁드립니다 !

- UserMajorTestCase
[GET] major/
[POST] user/major/
[DELETE] user/major/

- LectureTestCase
[GET] lecture/
[DELETE] lecture/
[PUT] lecture/<lecture_id>/position/

- SemesterTestCase
[GET] semester/<semester_id>/
[DELETE] semester/<semester_id>/