### PR TITLE
Refactor/userapi#69

### DIFF
--- a/snugh/user/serializers.py
+++ b/snugh/user/serializers.py
@@ -1,6 +1,54 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.authtoken.models import Token
 from django.contrib.auth.models import User
-from user.models import Major
+from user.models import *
+
+
+class UserCreateSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    token = serializers.SerializerMethodField()
+
+    email = serializers.EmailField(max_length=100)
+    password = serializers.CharField(max_length=100, min_length=6, write_only=True)
+    entrance_year = serializers.IntegerField(min_value=1000, max_value=9999, write_only=True)
+    full_name = serializers.CharField(max_length=30, min_length=2, write_only=True)
+    majors = serializers.ListField(child=serializers.JSONField(), allow_empty=False, write_only=True)
+    status = serializers.ChoiceField(choices=UserProfile.STUDENT_STATUS, write_only=True)
+
+    def get_token(self, user):
+        token, created = Token.objects.get_or_create(user=user)
+        return token.key
+
+    def validate_email(self, value):
+        if User.objects.filter(username=value).exists():
+            raise ValidationError({'email': "Already existing email."})
+        return value
+
+    def validate_major(self, value):
+        for major in value:
+            if major['major_type'] == Major.MAJOR:
+                return value
+        raise ValidationError({'majors': "major_type not_allowed"})
+
+    def validate(self, data):
+        data['username'] = data.get('email')
+        data['first_name'] = data.pop('full_name')
+        return data
+
+    def create(self, validated_data):
+        entrance_year = validated_data.pop('entrance_year')
+        student_status = validated_data.pop('status')
+        major_list = validated_data.pop('majors')
+
+        user = User.objects.create_user(**validated_data)
+        UserProfile.objects.create(user=user, entrance_year=entrance_year, status=student_status)
+
+        for major in major_list:
+            searched_major = Major.objects.get(major_name=major['major_name'], major_type=major['major_type'])
+            UserMajor.objects.create(user=user, major=searched_major)
+
+        return user
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/snugh/user/urls.py
+++ b/snugh/user/urls.py
@@ -12,5 +12,6 @@ router.register('major', MajorViewSet, basename='major')
 urlpatterns = [
     path('signup/', UserSignUpView.as_view(), name='signup'),
     path('login/', UserLoginView.as_view(), name='login'),
+    path('logout/', UserLogoutView.as_view(), name='logout'),
     path('', include((router.urls))),
 ]

--- a/snugh/user/urls.py
+++ b/snugh/user/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from user.views import UserSignUpView, UserViewSet, MajorViewSet
+from user.views import *
 
 
 app_name = 'user'
@@ -11,5 +11,6 @@ router.register('major', MajorViewSet, basename='major')
 
 urlpatterns = [
     path('signup/', UserSignUpView.as_view(), name='signup'),
+    path('login/', UserLoginView.as_view(), name='login'),
     path('', include((router.urls))),
 ]

--- a/snugh/user/urls.py
+++ b/snugh/user/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
-from user.views import UserViewSet, MajorViewSet
+from user.views import UserSignUpView, UserViewSet, MajorViewSet
 
 
 app_name = 'user'
@@ -10,5 +10,6 @@ router.register('user', UserViewSet, basename='user')
 router.register('major', MajorViewSet, basename='major')  
 
 urlpatterns = [
+    path('signup/', UserSignUpView.as_view(), name='signup'),
     path('', include((router.urls))),
 ]

--- a/snugh/user/views.py
+++ b/snugh/user/views.py
@@ -23,19 +23,128 @@ class UserSignUpView(GenericAPIView):
         login(request, user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+
 class UserLoginView(GenericAPIView):
     serializer_class = UserLoginSerializer
     permission_classes = (permissions.AllowAny, )
 
+    # PUT /login/
     def put(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
+class UserLogoutView(GenericAPIView):
+    permission_classes = (permissions.IsAuthenticated, )
+
+    # POST /logout/
+    def post(self, request):
+        request.user.auth_token.delete()
+        logout(request)
+        return Response(status=status.HTTP_200_OK)
+
+
 class UserViewSet(viewsets.GenericViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
+
+    # POST /user
+    @transaction.atomic
+    def create(self, request):
+        body = request.data
+
+        email = body.get('email')
+        password = body.get('password')
+        entrance_year = body.get('entrance_year')
+        full_name = body.get('full_name')
+        student_status = body.get('status')
+        major_list = body.get('majors')
+
+        error_list = []
+
+        # error case 1
+        if not email:
+            error_list.append('email')
+        if not password:
+            error_list.append('password')
+        if not entrance_year:
+            error_list.append('entrance_year')
+        if not full_name:
+            error_list.append('full_name')
+        if not student_status:
+            error_list.append('status')
+        if not major_list:
+            error_list.append('majors')
+
+        if len(error_list) > 0:
+            error_msg = ''
+            for error in error_list:
+                error_msg += (error + ', ')
+            error_msg = error_msg[:-2] + ' missing'
+            return Response({'error': error_msg}, status=status.HTTP_400_BAD_REQUEST)
+
+        # error case 2
+        list1 = [email, password, entrance_year, full_name, student_status]
+        list2 = ['str', 'str', 'int', 'str', 'str']
+        list3 = ['email', 'password', 'entrance_year', 'full_name', 'status']
+        for i in range(len(list1)):
+            if list2[i] == 'str':
+                isValid = isinstance(list1[i], str)
+            elif list2[i] == 'int':
+                isValid = isinstance(list1[i], int)
+            if not isValid:
+                error_list.append(list3[i])
+
+        if len(error_list) > 0:
+            error_msg = ''
+            for error in error_list:
+                error_msg += (error + ', ')
+            error_msg = error_msg[:-2]+' wrong_type'
+            return Response({'error': error_msg}, status=status.HTTP_400_BAD_REQUEST)
+
+        # error case 3
+        if '@' not in email:
+            return Response({'error':'email wrong_format'}, status=status.HTTP_400_BAD_REQUEST)
+        if len(password) < 6:
+            return Response({'error': 'password wrong_range(more than 6 letters)'}, status=status.HTTP_400_BAD_REQUEST)
+        if entrance_year < 1000 or entrance_year > 9999:
+            return Response({'error': 'entrance_year wrong_range(4 digits)'}, status=status.HTTP_400_BAD_REQUEST)
+        if len(full_name) < 2 or len(full_name) > 30:
+            return Response({'error': 'full_name wrong_range(2~30 letters)'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # error case 4
+        if self.get_queryset().filter(username=email).exists():
+            return Response({'error': 'email already_exist'}, status=status.HTTP_400_BAD_REQUEST)
+
+        # error case 5
+        if len(major_list) == 0:
+            return Response({'error': 'major missing'}, status=status.HTTP_400_BAD_REQUEST)
+        elif len(major_list) == 1:
+            major = major_list[0]
+            if major['major_type'] != Major.MAJOR:
+                return Response({'error': 'major_type not_allowed'}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            major_count = 0
+            for major in major_list:
+                if major['major_type'] == Major.MAJOR:
+                    major_count += 1
+            if major_count == 0:
+                return Response({'error': 'major_type not_allowed'}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = User.objects.create_user(username=email, email=email, password=password, first_name=full_name)
+        UserProfile.objects.create(user=user, entrance_year=entrance_year, status=student_status)
+
+        for major in major_list:
+            searched_major = Major.objects.get(major_name=major['major_name'], major_type=major['major_type'])
+            UserMajor.objects.create(user=user, major=searched_major)
+
+        login(request, user)
+
+        data = self.get_serializer(user).data
+        token, created = Token.objects.get_or_create(user=user)
+        data['token'] = token.key
+        return Response(data, status=status.HTTP_201_CREATED)
 
     # GET /user/logout
     @action(detail=False, methods=['GET'])

--- a/snugh/user/views.py
+++ b/snugh/user/views.py
@@ -2,7 +2,6 @@ from django.contrib.auth import authenticate, login, logout
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
 from rest_framework import status, permissions, viewsets
-from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.generics import GenericAPIView
@@ -17,12 +16,21 @@ class UserSignUpView(GenericAPIView):
     permission_classes = (permissions.AllowAny, )
 
     # POST /signup/
-    def post(self, request, *args, **kwargs):
+    def post(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         login(request, user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+class UserLoginView(GenericAPIView):
+    serializer_class = UserLoginSerializer
+    permission_classes = (permissions.AllowAny, )
+
+    def put(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class UserViewSet(viewsets.GenericViewSet):

--- a/snugh/user/views.py
+++ b/snugh/user/views.py
@@ -1,116 +1,33 @@
 from django.contrib.auth import authenticate, login, logout
 from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
-from rest_framework import status, viewsets
+from rest_framework import status, permissions, viewsets
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 from rest_framework.decorators import action
+from rest_framework.generics import GenericAPIView
 from django.contrib.auth.models import User
 from user.models import *
 from user.serializers import *
 from django.core.mail.message import EmailMessage
 
 
+class UserSignUpView(GenericAPIView):
+    serializer_class = UserCreateSerializer
+    permission_classes = (permissions.AllowAny, )
+
+    # POST /signup/
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        login(request, user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
 class UserViewSet(viewsets.GenericViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
-
-    # POST /user
-    @transaction.atomic
-    def create(self, request):
-        body = request.data
-
-        email = body.get('email')
-        password = body.get('password')
-        entrance_year = body.get('entrance_year')
-        full_name = body.get('full_name')
-        student_status = body.get('status')
-        major_list = body.get('majors')
-
-        error_list = []
-
-        # error case 1
-        if not email:
-            error_list.append('email')
-        if not password:
-            error_list.append('password')
-        if not entrance_year:
-            error_list.append('entrance_year')
-        if not full_name:
-            error_list.append('full_name')
-        if not student_status:
-            error_list.append('status')
-        if not major_list:
-            error_list.append('majors')
-
-        if len(error_list) > 0:
-            error_msg = ''
-            for error in error_list:
-                error_msg += (error + ', ')
-            error_msg = error_msg[:-2] + ' missing'
-            return Response({'error': error_msg}, status=status.HTTP_400_BAD_REQUEST)
-
-        # error case 2
-        list1 = [email, password, entrance_year, full_name, student_status]
-        list2 = ['str', 'str', 'int', 'str', 'str']
-        list3 = ['email', 'password', 'entrance_year', 'full_name', 'status']
-        for i in range(len(list1)):
-            if list2[i] == 'str':
-                isValid = isinstance(list1[i], str)
-            elif list2[i] == 'int':
-                isValid = isinstance(list1[i], int)
-            if not isValid:
-                error_list.append(list3[i])
-
-        if len(error_list) > 0:
-            error_msg = ''
-            for error in error_list:
-                error_msg += (error + ', ')
-            error_msg = error_msg[:-2]+' wrong_type'
-            return Response({'error': error_msg}, status=status.HTTP_400_BAD_REQUEST)
-
-        # error case 3
-        if '@' not in email:
-            return Response({'error':'email wrong_format'}, status=status.HTTP_400_BAD_REQUEST)
-        if len(password) < 6:
-            return Response({'error': 'password wrong_range(more than 6 letters)'}, status=status.HTTP_400_BAD_REQUEST)
-        if entrance_year < 1000 or entrance_year > 9999:
-            return Response({'error': 'entrance_year wrong_range(4 digits)'}, status=status.HTTP_400_BAD_REQUEST)
-        if len(full_name) < 2 or len(full_name) > 30:
-            return Response({'error': 'full_name wrong_range(2~30 letters)'}, status=status.HTTP_400_BAD_REQUEST)
-
-        # error case 4
-        if self.get_queryset().filter(username=email).exists():
-            return Response({'error': 'email already_exist'}, status=status.HTTP_400_BAD_REQUEST)
-
-        # error case 5
-        if len(major_list) == 0:
-            return Response({'error': 'major missing'}, status=status.HTTP_400_BAD_REQUEST)
-        elif len(major_list) == 1:
-            major = major_list[0]
-            if major['major_type'] != Major.MAJOR:
-                return Response({'error': 'major_type not_allowed'}, status=status.HTTP_400_BAD_REQUEST)
-        else:
-            major_count = 0
-            for major in major_list:
-                if major['major_type'] == Major.MAJOR:
-                    major_count += 1
-            if major_count == 0:
-                return Response({'error': 'major_type not_allowed'}, status=status.HTTP_400_BAD_REQUEST)
-
-        user = User.objects.create_user(username=email, email=email, password=password, first_name=full_name)
-        UserProfile.objects.create(user=user, entrance_year=entrance_year, status=student_status)
-
-        for major in major_list:
-            searched_major = Major.objects.get(major_name=major['major_name'], major_type=major['major_type'])
-            UserMajor.objects.create(user=user, major=searched_major)
-
-        login(request, user)
-
-        data = self.get_serializer(user).data
-        token, created = Token.objects.get_or_create(user=user)
-        data['token'] = token.key
-        return Response(data, status=status.HTTP_201_CREATED)
 
     # GET /user/logout
     @action(detail=False, methods=['GET'])

--- a/snugh/user/views.py
+++ b/snugh/user/views.py
@@ -38,8 +38,8 @@ class UserLoginView(GenericAPIView):
 class UserLogoutView(GenericAPIView):
     permission_classes = (permissions.IsAuthenticated, )
 
-    # POST /logout/
-    def post(self, request):
+    # GET /logout/
+    def get(self, request):
         request.user.auth_token.delete()
         logout(request)
         return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
resolve #69 
User API 관련 코드 refactor했습니다.

## POST /user/
- Password 길이는 임의로 최대가 100이 되도록 설정하였습니다.
- 400 error가 나야하는 request에 대해서는 동일하게 오류가 발생하도록 하였으나, "password wrong range"와 같이 상세한 오류 원인은 일일이 반환하지 않도록 하였습니다. 이 부분은 프런트에서 입력을 받을 때 request 날리기 전 처리해주는 것이 적합한 것 같습니다.
- 회원가입 API는 response body가 복잡할 필요가 없다고 판단하여 user_id, email, token만 반환하도록 하였습니다.
- 임시로 url을 POST /signup/으로 변경해둔 상태입니다.

## PUT /user/login/
- 로그인 API 역시 response body가 복잡할 필요가 없다고 판단하여 user_id, email, token만 반환하도록 하였습니다.
- 임시로 url을 PUT /login/으로 변경해둔 상태입니다.

## GET /user/logout/
- 임시로 url을 GET /logout/으로 변경해둔 상태입니다.